### PR TITLE
Fix bug where listeners where stacking each time the view was created

### DIFF
--- a/Sources/Mailbox.swift
+++ b/Sources/Mailbox.swift
@@ -32,6 +32,10 @@ public final class Mailbox<MessageType> {
 
 extension Mailbox {
     
+    internal func unregisterSubscribers() {
+        subscribers = []
+    }
+    
     internal func dispatch(message: MessageType) {
         subscribers.forEach { $0(message) }
     }

--- a/Sources/UIKit/PortalViewController.swift
+++ b/Sources/UIKit/PortalViewController.swift
@@ -38,6 +38,7 @@ public final class PortalViewController<MessageType, RendererType: Renderer>: UI
         // parent is a navigation controller because if not the view
         // does not take into account the navigation bar in order
         // to sets its visible size.
+        mailbox.unregisterSubscribers()
         self.view = UIView(frame: calculateViewBounds())
         let renderer = createRenderer(view)
         let componentMailbox = renderer.render(component: component)


### PR DESCRIPTION
Using a button as an example. Every time a button is created, it subscribes itself to an onTap message given by the user, with a result closure. This closure was being subscribe to the mailbox, where it would reside. This would cause each time you created a button, a new subscription was being register, even when the older was still in the mailbox.

This PR fixes so that every time a view is created, the mailbox subscriptions are unregistered so that the only subscriptions are the ones being created by the components in the current view