### PR TITLE
Clip to bounds images

### DIFF
--- a/Sources/UIKit/Renderers/ImageViewRenderer.swift
+++ b/Sources/UIKit/Renderers/ImageViewRenderer.swift
@@ -16,6 +16,7 @@ internal struct ImageViewRenderer<MessageType>: UIKitRenderer {
     
     func render(with layoutEngine: LayoutEngine, isDebugModeEnabled: Bool) -> Render<MessageType> {
         let imageView = UIImageView(image: image.asUIImage)
+        imageView.clipsToBounds = true
         
         imageView.apply(style: style.base)
         layoutEngine.apply(layout: layout, to: imageView)


### PR DESCRIPTION
This will clip every image to the bounds of the UIImageView, so if there is no rounded corners then nothing happens but if the corners are rounded then the image will clip it's corners too.