### PR TITLE
Split Collection into 2 components

### DIFF
--- a/PortalView.xcodeproj/project.pbxproj
+++ b/PortalView.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		52DB3C1F1E9E483F0078373D /* TextFieldRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DB3C1E1E9E483F0078373D /* TextFieldRenderer.swift */; };
-		52DB3C211E9E48480078373D /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DB3C201E9E48480078373D /* TextField.swift */; };
 		464F9E861E943D8E009F774A /* CollectionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464F9E851E943D8E009F774A /* CollectionRenderer.swift */; };
 		464F9E8A1E944051009F774A /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464F9E891E944051009F774A /* Collection.swift */; };
 		464F9E8C1E944634009F774A /* PortalCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464F9E8B1E944634009F774A /* PortalCollectionView.swift */; };
 		464F9E8E1E94464F009F774A /* PortalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464F9E8D1E94464F009F774A /* PortalCollectionViewCell.swift */; };
+		52DB3C1F1E9E483F0078373D /* TextFieldRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DB3C1E1E9E483F0078373D /* TextFieldRenderer.swift */; };
+		52DB3C211E9E48480078373D /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DB3C201E9E48480078373D /* TextField.swift */; };
 		9D66880E1E534BDE0090008B /* PortalView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D6688041E534BDE0090008B /* PortalView.framework */; };
 		9D6AD93E1E534C7600DDD9D8 /* StyleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6AD9341E534C7600DDD9D8 /* StyleSheet.swift */; };
 		9D6AD93F1E534C7600DDD9D8 /* Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6AD9351E534C7600DDD9D8 /* Portal.swift */; };
@@ -55,6 +55,9 @@
 		D862D1A51E9D16CC00FAAF0D /* Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862D1A41E9D16CC00FAAF0D /* Progress.swift */; };
 		D862D1A71E9D16E300FAAF0D /* ProgressRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862D1A61E9D16E300FAAF0D /* ProgressRenderer.swift */; };
 		D862D1A91E9D1B7600FAAF0D /* ProgressCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862D1A81E9D1B7600FAAF0D /* ProgressCounter.swift */; };
+		D859EF4E1EA5165E002701E1 /* Carousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D859EF4D1EA5165E002701E1 /* Carousel.swift */; };
+		D859EF521EA51E8C002701E1 /* PortalCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D859EF511EA51E8C002701E1 /* PortalCarouselView.swift */; };
+		D859EF541EA54162002701E1 /* CarouselRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D859EF531EA54162002701E1 /* CarouselRenderer.swift */; };
 		D86738751E94374300B42F37 /* Segmented.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86738741E94374300B42F37 /* Segmented.swift */; };
 		D86738771E9437F600B42F37 /* SegmentedRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86738761E9437F600B42F37 /* SegmentedRenderer.swift */; };
 /* End PBXBuildFile section */
@@ -70,12 +73,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		52DB3C1E1E9E483F0078373D /* TextFieldRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldRenderer.swift; path = Sources/UIKit/Renderers/TextFieldRenderer.swift; sourceTree = "<group>"; };
-		52DB3C201E9E48480078373D /* TextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextField.swift; path = Sources/Components/TextField.swift; sourceTree = "<group>"; };
 		464F9E851E943D8E009F774A /* CollectionRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CollectionRenderer.swift; path = Sources/UIKit/Renderers/CollectionRenderer.swift; sourceTree = "<group>"; };
 		464F9E891E944051009F774A /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Collection.swift; path = Sources/Components/Collection.swift; sourceTree = "<group>"; };
 		464F9E8B1E944634009F774A /* PortalCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PortalCollectionView.swift; path = Sources/UIKit/PortalCollectionView.swift; sourceTree = "<group>"; };
 		464F9E8D1E94464F009F774A /* PortalCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PortalCollectionViewCell.swift; path = Sources/UIKit/PortalCollectionViewCell.swift; sourceTree = "<group>"; };
+		52DB3C1E1E9E483F0078373D /* TextFieldRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldRenderer.swift; path = Sources/UIKit/Renderers/TextFieldRenderer.swift; sourceTree = "<group>"; };
+		52DB3C201E9E48480078373D /* TextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextField.swift; path = Sources/Components/TextField.swift; sourceTree = "<group>"; };
 		9D6688041E534BDE0090008B /* PortalView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PortalView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D66880D1E534BDE0090008B /* PortalViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PortalViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D6AD9341E534C7600DDD9D8 /* StyleSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StyleSheet.swift; path = Sources/StyleSheet.swift; sourceTree = "<group>"; };
@@ -119,6 +122,9 @@
 		D862D1A41E9D16CC00FAAF0D /* Progress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Progress.swift; path = Sources/Components/Progress.swift; sourceTree = "<group>"; };
 		D862D1A61E9D16E300FAAF0D /* ProgressRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProgressRenderer.swift; path = Sources/UIKit/Renderers/ProgressRenderer.swift; sourceTree = "<group>"; };
 		D862D1A81E9D1B7600FAAF0D /* ProgressCounter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProgressCounter.swift; path = Sources/ProgressCounter.swift; sourceTree = "<group>"; };
+		D859EF4D1EA5165E002701E1 /* Carousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Carousel.swift; path = Sources/Components/Carousel.swift; sourceTree = "<group>"; };
+		D859EF511EA51E8C002701E1 /* PortalCarouselView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PortalCarouselView.swift; path = Sources/UIKit/PortalCarouselView.swift; sourceTree = "<group>"; };
+		D859EF531EA54162002701E1 /* CarouselRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CarouselRenderer.swift; path = Sources/UIKit/Renderers/CarouselRenderer.swift; sourceTree = "<group>"; };
 		D86738741E94374300B42F37 /* Segmented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Segmented.swift; path = Sources/Components/Segmented.swift; sourceTree = "<group>"; };
 		D86738761E9437F600B42F37 /* SegmentedRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SegmentedRenderer.swift; path = Sources/UIKit/Renderers/SegmentedRenderer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -192,6 +198,7 @@
 				9D6AD96E1E535B1E00DDD9D8 /* PortalViewController.swift */,
 				9D6AD97C1E535F7100DDD9D8 /* PortalNavigationController.swift */,
 				464F9E8B1E944634009F774A /* PortalCollectionView.swift */,
+				D859EF511EA51E8C002701E1 /* PortalCarouselView.swift */,
 				464F9E8D1E94464F009F774A /* PortalCollectionViewCell.swift */,
 				9D6AD9781E535E5100DDD9D8 /* UIKitRenderer.swift */,
 				9D6AD9801E53612500DDD9D8 /* UIKitComponentManager.swift */,
@@ -213,7 +220,8 @@
 				9D6AD9521E534CAF00DDD9D8 /* Button.swift */,
 				D86738741E94374300B42F37 /* Segmented.swift */,
 				D862D1A41E9D16CC00FAAF0D /* Progress.swift */,
-				464F9E891E944051009F774A /* Collection.swift */
+				464F9E891E944051009F774A /* Collection.swift */,
+				D859EF4D1EA5165E002701E1 /* Carousel.swift */
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -251,7 +259,8 @@
 				D86738761E9437F600B42F37 /* SegmentedRenderer.swift */,
 				D862D1A61E9D16E300FAAF0D /* ProgressRenderer.swift */,
 				464F9E851E943D8E009F774A /* CollectionRenderer.swift */,
-				9D93F21F1E9C4FBB00B36914 /* ComponentRenderer.swift */
+				9D93F21F1E9C4FBB00B36914 /* ComponentRenderer.swift */,
+				D859EF531EA54162002701E1 /* CarouselRenderer.swift */,
 			);
 			name = Renderers;
 			sourceTree = "<group>";
@@ -380,6 +389,8 @@
 				9D6AD9561E534CAF00DDD9D8 /* Label.swift in Sources */,
 				D862D1A71E9D16E300FAAF0D /* ProgressRenderer.swift in Sources */,
 				9D6AD9411E534C7600DDD9D8 /* LayoutEngine.swift in Sources */,
+				D859EF521EA51E8C002701E1 /* PortalCarouselView.swift in Sources */,
+				D859EF4E1EA5165E002701E1 /* Carousel.swift in Sources */,
 				9D6AD9811E53612500DDD9D8 /* UIKitComponentManager.swift in Sources */,
 				52DB3C211E9E48480078373D /* TextField.swift in Sources */,
 				9D6AD9771E535DDA00DDD9D8 /* ImageViewRenderer.swift in Sources */,
@@ -391,6 +402,7 @@
 				9D6AD9671E53589600DDD9D8 /* ButtonRenderer.swift in Sources */,
 				9D6AD9791E535E5100DDD9D8 /* UIKitRenderer.swift in Sources */,
 				9D6AD9541E534CAF00DDD9D8 /* NavigationBar.swift in Sources */,
+				D859EF541EA54162002701E1 /* CarouselRenderer.swift in Sources */,
 				9D6AD9711E535B7600DDD9D8 /* TableRenderer.swift in Sources */,
 				D862D1A91E9D1B7600FAAF0D /* ProgressCounter.swift in Sources */,
 				464F9E8C1E944634009F774A /* PortalCollectionView.swift in Sources */,
@@ -403,7 +415,6 @@
 				9D6AD9731E535C0300DDD9D8 /* MapViewRenderer.swift in Sources */,
 				9D6AD9581E534CAF00DDD9D8 /* Button.swift in Sources */,
 				52DB3C1F1E9E483F0078373D /* TextFieldRenderer.swift in Sources */,
-				9D6AD97B1E535F2000DDD9D8 /* ComponentRenderer.swift in Sources */,
 				9D6AD9531E534CAF00DDD9D8 /* Table.swift in Sources */,
 				9D6AD96F1E535B1E00DDD9D8 /* PortalViewController.swift in Sources */,
 				9D93F2201E9C4FBB00B36914 /* ComponentRenderer.swift in Sources */,

--- a/Sources/Component.swift
+++ b/Sources/Component.swift
@@ -43,6 +43,7 @@ public indirect enum Component<MessageType> {
     case container([Component<MessageType>], StyleSheet<EmptyStyleSheet>, Layout)
     case table(TableProperties<MessageType>, StyleSheet<TableStyleSheet>, Layout)
     case collection(CollectionProperties<MessageType>, StyleSheet<EmptyStyleSheet>, Layout)
+    case carousel(CarouselProperties<MessageType>, StyleSheet<EmptyStyleSheet>, Layout)
     case touchable(gesture: Gesture<MessageType>, child: Component<MessageType>)
     case segmented(ZipList<SegmentProperties<MessageType>>, StyleSheet<SegmentedStyleSheet>, Layout)
     case progress(ProgressCounter, StyleSheet<ProgressStyleSheet>, Layout)
@@ -83,6 +84,9 @@ public indirect enum Component<MessageType> {
             return layout
             
         case .collection(_, _, let layout):
+            return layout
+            
+        case .carousel(_, _, let layout):
             return layout
 
         case .custom(_, let layout):
@@ -130,6 +134,9 @@ extension Component {
 
         case .collection(let properties, let style, let layout):
             return .collection(properties.map(transform), style, layout)
+            
+        case .carousel(let properties, let style, let layout):
+            return .carousel(properties.map(transform), style, layout)
 
         case .custom(let componentIdentifier, let layout):
             return .custom(componentIdentifier: componentIdentifier, layout: layout)

--- a/Sources/Components/Carousel.swift
+++ b/Sources/Components/Carousel.swift
@@ -1,0 +1,113 @@
+//
+//  Carousel.swift
+//  PortalView
+//
+//  Created by Cristian Ames on 4/17/17.
+//  Copyright © 2017 Guido Marucci Blas. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public struct CarouselProperties<MessageType> {
+    
+    public var items: ZipList<CarouselItemProperties<MessageType>>?
+    public var showsScrollIndicator: Bool
+    public var isSnapToCellEnabled: Bool
+    
+    // Layout properties
+    public var itemsWidth: UInt
+    public var itemsHeight: UInt
+    public var minimumInteritemSpacing: UInt
+    public var minimumLineSpacing: UInt
+    public var sectionInset: SectionInset
+    
+    fileprivate init(
+        items: ZipList<CarouselItemProperties<MessageType>>?,
+        showsScrollIndicator: Bool = false,
+        isSnapToCellEnabled: Bool = false,
+        itemsWidth: UInt,
+        itemsHeight: UInt,
+        minimumInteritemSpacing: UInt = 0,
+        minimumLineSpacing: UInt = 0,
+        sectionInset: SectionInset = .zero,
+        selected: UInt = 0) {
+        self.items = items
+        self.showsScrollIndicator = showsScrollIndicator
+        self.isSnapToCellEnabled = isSnapToCellEnabled
+        self.itemsWidth = itemsWidth
+        self.itemsHeight = itemsHeight
+        self.minimumLineSpacing = minimumLineSpacing
+        self.minimumInteritemSpacing = minimumInteritemSpacing
+        self.sectionInset = sectionInset
+    }
+    
+    public func map<NewMessageType>(_ transform: @escaping (MessageType) -> NewMessageType) -> CarouselProperties<NewMessageType> {
+        return CarouselProperties<NewMessageType>(
+            items: self.items.map { $0.map { $0.map(transform) } },
+            showsScrollIndicator: self.showsScrollIndicator,
+            isSnapToCellEnabled: self.isSnapToCellEnabled,
+            itemsWidth: self.itemsWidth,
+            itemsHeight: self.itemsHeight,
+            minimumInteritemSpacing: self.minimumInteritemSpacing,
+            minimumLineSpacing: self.minimumLineSpacing,
+            sectionInset: self.sectionInset)
+    }
+    
+}
+
+public struct CarouselItemProperties<MessageType> {
+    
+    public typealias Renderer = () -> Component<MessageType>
+    
+    public let onTap: MessageType?
+    public let onScrolled: MessageType?
+    public let renderer: Renderer
+    public let identifier: String
+    
+    fileprivate init(
+        onTap: MessageType?,
+        onScrolled: MessageType?,
+        identifier: String,
+        renderer: @escaping Renderer) {
+        self.onTap = onTap
+        self.onScrolled = onScrolled
+        self.renderer = renderer
+        self.identifier = identifier
+    }
+    
+}
+
+extension CarouselItemProperties {
+    
+    public func map<NewMessageType>(_ transform: @escaping (MessageType) -> NewMessageType) -> CarouselItemProperties<NewMessageType> {
+        return CarouselItemProperties<NewMessageType>(
+            onTap: self.onTap.map(transform),
+            onScrolled: self.onScrolled.map(transform),
+            identifier: self.identifier,
+            renderer: { self.renderer().map(transform) }
+        )
+    }
+    
+}
+
+public func carousel<MessageType>(
+    properties: CarouselProperties<MessageType>,
+    style: StyleSheet<EmptyStyleSheet> = EmptyStyleSheet.default,
+    layout: Layout = layout()) -> Component<MessageType> {
+    return .carousel(properties, style, layout)
+}
+
+public func carouselItem<MessageType>(
+    onTap: MessageType? = .none,
+    onScrolled: MessageType? = .none,
+    identifier: String,
+    renderer: @escaping CarouselItemProperties<MessageType>.Renderer) -> CarouselItemProperties<MessageType> {
+    return CarouselItemProperties(onTap: onTap, onScrolled: onScrolled, identifier: identifier, renderer: renderer)
+}
+
+public func properties<MessageType>(itemsWidth: UInt, itemsHeight: UInt, items: ZipList<CarouselItemProperties<MessageType>>?, configure: (inout CarouselProperties<MessageType>) -> ()) -> CarouselProperties<MessageType> {
+    var properties = CarouselProperties<MessageType>(items: items, itemsWidth: itemsWidth, itemsHeight: itemsHeight)
+    configure(&properties)
+    return properties
+}

--- a/Sources/Components/Collection.swift
+++ b/Sources/Components/Collection.swift
@@ -36,7 +36,6 @@ public struct CollectionProperties<MessageType> {
     public var items: [CollectionItemProperties<MessageType>]
     public var showsVerticalScrollIndicator: Bool
     public var showsHorizontalScrollIndicator: Bool
-    public var isSnapToCellEnabled: Bool
     
     // Layout properties
     public var itemsWidth: UInt
@@ -50,7 +49,6 @@ public struct CollectionProperties<MessageType> {
         items: [CollectionItemProperties<MessageType>] = [],
         showsVerticalScrollIndicator: Bool = false,
         showsHorizontalScrollIndicator: Bool = false,
-        isSnapToCellEnabled: Bool = false,
         itemsWidth: UInt,
         itemsHeight: UInt,
         minimumInteritemSpacing: UInt = 0,
@@ -60,7 +58,6 @@ public struct CollectionProperties<MessageType> {
         self.items = items
         self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
         self.showsHorizontalScrollIndicator = showsHorizontalScrollIndicator
-        self.isSnapToCellEnabled = isSnapToCellEnabled
         self.itemsWidth = itemsWidth
         self.itemsHeight = itemsHeight
         self.minimumLineSpacing = minimumLineSpacing
@@ -74,7 +71,6 @@ public struct CollectionProperties<MessageType> {
             items: self.items.map { $0.map(transform) },
             showsVerticalScrollIndicator: self.showsVerticalScrollIndicator,
             showsHorizontalScrollIndicator: self.showsHorizontalScrollIndicator,
-            isSnapToCellEnabled: self.isSnapToCellEnabled,
             itemsWidth: self.itemsWidth,
             itemsHeight: self.itemsHeight,
             minimumInteritemSpacing: self.minimumInteritemSpacing,

--- a/Sources/UIKit/PortalCarouselView.swift
+++ b/Sources/UIKit/PortalCarouselView.swift
@@ -14,7 +14,7 @@ public final class PortalCarouselView<MessageType, CustomComponentRendererType: 
     
     fileprivate let onSelectionChange: (ZipListShiftOperation) -> MessageType?
     fileprivate var lastOffset: CGFloat = 0
-    fileprivate var selected: Int = 0
+    fileprivate var selectedIndex: Int = 0
     
     public override init(items: [CollectionItemProperties<MessageType>], customComponentRenderer: CustomComponentRendererType, layoutEngine: LayoutEngine, layout: UICollectionViewLayout) {
         onSelectionChange = { _ in .none }
@@ -29,10 +29,10 @@ public final class PortalCarouselView<MessageType, CustomComponentRendererType: 
                     identifier: item.identifier,
                     renderer: item.renderer)
             }
-            selected = Int(items.centerIndex)
+            selectedIndex = Int(items.centerIndex)
             self.onSelectionChange = onSelectionChange
             super.init(items: items.map(transform), customComponentRenderer: customComponentRenderer, layoutEngine: layoutEngine, layout: layout)
-            scrollToItem(self.selected, animated: false)
+            scrollToItem(self.selectedIndex, animated: false)
         } else {
             self.onSelectionChange = onSelectionChange
             super.init(items: [], customComponentRenderer: customComponentRenderer, layoutEngine: layoutEngine, layout: layout)
@@ -58,19 +58,19 @@ public final class PortalCarouselView<MessageType, CustomComponentRendererType: 
             return
         }
         
-        let lastPosition = selected
+        let lastPosition = selectedIndex
         if currentOffset > lastOffset {
             if lastPosition < items.count - 1 {
-                selected = lastPosition + 1 // Move to the right
-                scrollToItem(selected, animated: true)
+                selectedIndex = lastPosition + 1 // Move to the right
+                scrollToItem(selectedIndex, animated: true)
             }
         } else if currentOffset < lastOffset {
             if lastPosition >= 1 {
-                selected = lastPosition - 1
-                scrollToItem(selected, animated: true) // Move to the left
+                selectedIndex = lastPosition - 1
+                scrollToItem(selectedIndex, animated: true) // Move to the left
             }
         }
-        let shift = shiftDirection(actual: selected, old: lastPosition)
+        let shift = shiftDirection(actual: selectedIndex, old: lastPosition)
         shift.flatMap(onSelectionChange) |> { mailbox.dispatch(message: $0) }
     }
     

--- a/Sources/UIKit/PortalCarouselView.swift
+++ b/Sources/UIKit/PortalCarouselView.swift
@@ -1,0 +1,89 @@
+//
+//  PortalCarouselView.swift
+//  PortalView
+//
+//  Created by Cristian Ames on 4/17/17.
+//  Copyright © 2017 Guido Marucci Blas. All rights reserved.
+//
+import UIKit
+
+public final class PortalCarouselView<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: PortalCollectionView<MessageType, CustomComponentRendererType>
+    where CustomComponentRendererType.MessageType == MessageType {
+    
+    public var isSnapToCellEnabled: Bool = false
+    
+    fileprivate let scrolledMessages: [MessageType?]
+    fileprivate var lastOffset: CGFloat = 0
+    fileprivate var selected: Int = 0 { didSet {
+            scrolledMessages[selected] |> { mailbox.dispatch(message: $0) }
+        }
+    }
+    
+    public override init(items: [CollectionItemProperties<MessageType>], customComponentRenderer: CustomComponentRendererType, layoutEngine: LayoutEngine, layout: UICollectionViewLayout) {
+        scrolledMessages = items.map { _ in .none }
+        super.init(items: items, customComponentRenderer: customComponentRenderer, layoutEngine: layoutEngine, layout: layout)
+    }
+    
+    public init(items: ZipList<CarouselItemProperties<MessageType>>?, customComponentRenderer: CustomComponentRendererType, layoutEngine: LayoutEngine, layout: UICollectionViewLayout) {
+        if let items = items {
+            let transform = { (item: CarouselItemProperties) -> CollectionItemProperties<MessageType> in
+                return collectionItem(
+                    onTap: item.onTap,
+                    identifier: item.identifier,
+                    renderer: item.renderer)
+            }
+            selected = Int(items.centerIndex)
+            scrolledMessages = items.map { $0.onScrolled }
+            super.init(items: items.map(transform), customComponentRenderer: customComponentRenderer, layoutEngine: layoutEngine, layout: layout)
+            scrollToItem(self.selected, animated: false)
+        } else {
+            scrolledMessages = []
+            super.init(items: [], customComponentRenderer: customComponentRenderer, layoutEngine: layoutEngine, layout: layout)
+        }
+        
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        lastOffset = scrollView.contentOffset.x
+    }
+    
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint,
+                                          targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        guard isSnapToCellEnabled else { return }
+        
+        let currentOffset = CGFloat(scrollView.contentOffset.x)
+        
+        if currentOffset == lastOffset {
+            return
+        }
+        
+        let lastPosition = selected
+        if currentOffset > lastOffset {
+            if lastPosition < items.count - 1 {
+                selected = lastPosition + 1 // Move to the right
+                scrollToItem(selected, animated: true)
+            }
+        } else if currentOffset < lastOffset {
+            if lastPosition >= 1 {
+                selected = lastPosition - 1
+                scrollToItem(selected, animated: true) // Move to the left
+            }
+        }
+    }
+    
+}
+
+fileprivate extension PortalCarouselView {
+    
+    fileprivate func scrollToItem(_ position: Int, animated: Bool) {
+        DispatchQueue.main.async {
+            let indexPath = IndexPath(item: position, section: 0)
+            self.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
+        }
+    }
+    
+}

--- a/Sources/UIKit/PortalCarouselView.swift
+++ b/Sources/UIKit/PortalCarouselView.swift
@@ -61,17 +61,17 @@ public final class PortalCarouselView<MessageType, CustomComponentRendererType: 
         let lastPosition = selectedIndex
         if currentOffset > lastOffset {
             if lastPosition < items.count - 1 {
-                selectedIndex = lastPosition + 1 // Move to the right
-                scrollToItem(selectedIndex, animated: true)
+                selectedIndex = lastPosition + 1
+                scrollToItem(selectedIndex, animated: true) // Move to the right
+                onSelectionChange(.left(count: 1)) |> { mailbox.dispatch(message: $0) }
             }
         } else if currentOffset < lastOffset {
             if lastPosition >= 1 {
                 selectedIndex = lastPosition - 1
                 scrollToItem(selectedIndex, animated: true) // Move to the left
+                onSelectionChange(.right(count: 1)) |> { mailbox.dispatch(message: $0) }
             }
         }
-        let shift = shiftDirection(actual: selectedIndex, old: lastPosition)
-        shift.flatMap(onSelectionChange) |> { mailbox.dispatch(message: $0) }
     }
     
 }

--- a/Sources/UIKit/PortalCarouselView.swift
+++ b/Sources/UIKit/PortalCarouselView.swift
@@ -50,6 +50,12 @@ public final class PortalCarouselView<MessageType, CustomComponentRendererType: 
     
     public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        
+        // At this moment we only support the message feature with the snap mode on.
+        // TODO: Add support for messaging regardless the snap mode. 
+        // To do this feature we should detect the item selected not by adding or 
+        // supressing one to the index but searching the active item in the screen 
+        // at that moment. We could use `indexPathForItemAtPoint` for this purpose.
         guard isSnapToCellEnabled else { return }
         
         let currentOffset = CGFloat(scrollView.contentOffset.x)

--- a/Sources/UIKit/PortalCollectionView.swift
+++ b/Sources/UIKit/PortalCollectionView.swift
@@ -8,18 +8,15 @@
 
 import UIKit
 
-public final class PortalCollectionView<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UICollectionView, UICollectionViewDataSource, UICollectionViewDelegate
+public class PortalCollectionView<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UICollectionView, UICollectionViewDataSource, UICollectionViewDelegate
     where CustomComponentRendererType.MessageType == MessageType {
     
     public let mailbox = Mailbox<MessageType>()
     public var isDebugModeEnabled: Bool = false
-    public var isSnapToCellEnabled: Bool = false
     
-    fileprivate let layoutEngine: LayoutEngine
-    fileprivate let items: [CollectionItemProperties<MessageType>]
-    fileprivate var selected: Int = 0
-    fileprivate var lastOffset: CGFloat = 0
-    fileprivate let customComponentRenderer: CustomComponentRendererType
+    let layoutEngine: LayoutEngine
+    let items: [CollectionItemProperties<MessageType>]
+    let customComponentRenderer: CustomComponentRendererType
     
     public init(items: [CollectionItemProperties<MessageType>], customComponentRenderer: CustomComponentRendererType, layoutEngine: LayoutEngine, layout: UICollectionViewLayout) {
         self.items = items
@@ -63,44 +60,9 @@ public final class PortalCollectionView<MessageType, CustomComponentRendererType
         item.onTap |> { mailbox.dispatch(message: $0) }
     }
     
-    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        lastOffset = scrollView.contentOffset.x
-    }
-    
-    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint,
-                                          targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        guard isSnapToCellEnabled else { return }
-        
-        let currentOffset = CGFloat(scrollView.contentOffset.x)
-        
-        if currentOffset == lastOffset {
-            return
-        }
-        
-        let lastPosition = selected
-        if currentOffset > lastOffset {
-            if lastPosition < items.count - 1 {
-                selected = lastPosition + 1 // Move to the right
-                scrollToItem(selected, animated: true)
-            }
-        } else if currentOffset < lastOffset {
-            if lastPosition >= 1 {
-                selected = lastPosition - 1
-                scrollToItem(selected, animated: true) // Move to the left
-            }
-        }
-    }
-    
 }
 
 fileprivate extension PortalCollectionView {
-    
-    fileprivate func scrollToItem(_ position: Int, animated: Bool) {
-        DispatchQueue.main.async {
-            let indexPath = IndexPath(item: position, section: 0)
-            self.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
-        }
-    }
 
     fileprivate func dequeueReusableCell(with identifier: String, for indexPath: IndexPath) -> PortalCollectionViewCell<MessageType, CustomComponentRendererType>? {
         if let cell = dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as? PortalCollectionViewCell<MessageType, CustomComponentRendererType> {

--- a/Sources/UIKit/Renderers/CarouselRenderer.swift
+++ b/Sources/UIKit/Renderers/CarouselRenderer.swift
@@ -21,7 +21,8 @@ where CustomComponentRendererType.MessageType == MessageType {
             items: properties.items,
             customComponentRenderer: customComponentRenderer,
             layoutEngine: layoutEngine,
-            layout: createFlowLayout()
+            layout: createFlowLayout(),
+            onSelectionChange: properties.onSelectionChange
         )
         
         carouselView.isDebugModeEnabled = isDebugModeEnabled

--- a/Sources/UIKit/Renderers/CarouselRenderer.swift
+++ b/Sources/UIKit/Renderers/CarouselRenderer.swift
@@ -1,37 +1,37 @@
 //
-//  PortalCollectionView.swift
+//  CarouselRenderer.swift
 //  PortalView
 //
-//  Created by Argentino Ducret on 4/4/17.
+//  Created by Cristian Ames on 4/17/17.
 //  Copyright © 2017 Guido Marucci Blas. All rights reserved.
 //
 
 import UIKit
 
-internal struct CollectionRenderer<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UIKitRenderer
-    where CustomComponentRendererType.MessageType == MessageType {
+internal struct CarouselRenderer<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UIKitRenderer
+where CustomComponentRendererType.MessageType == MessageType {
     
     let customComponentRenderer: CustomComponentRendererType
-    let properties: CollectionProperties<MessageType>
+    let properties: CarouselProperties<MessageType>
     let style: StyleSheet<EmptyStyleSheet>
     let layout: Layout
     
     func render(with layoutEngine: LayoutEngine, isDebugModeEnabled: Bool) -> Render<MessageType> {
-        let collectionView = PortalCollectionView(
+        let carouselView = PortalCarouselView(
             items: properties.items,
             customComponentRenderer: customComponentRenderer,
             layoutEngine: layoutEngine,
             layout: createFlowLayout()
         )
         
-        collectionView.isDebugModeEnabled = isDebugModeEnabled
-        collectionView.showsHorizontalScrollIndicator = properties.showsHorizontalScrollIndicator
-        collectionView.showsVerticalScrollIndicator = properties.showsVerticalScrollIndicator
+        carouselView.isDebugModeEnabled = isDebugModeEnabled
+        carouselView.isSnapToCellEnabled = properties.isSnapToCellEnabled
+        carouselView.showsHorizontalScrollIndicator = properties.showsScrollIndicator
         
-        collectionView.apply(style: style.base)
-        layoutEngine.apply(layout: layout, to: collectionView)
+        carouselView.apply(style: style.base)
+        layoutEngine.apply(layout: layout, to: carouselView)
         
-        return Render(view: collectionView, mailbox: collectionView.mailbox)
+        return Render(view: carouselView, mailbox: carouselView.mailbox)
     }
     
     func createFlowLayout() -> UICollectionViewFlowLayout {
@@ -46,14 +46,8 @@ internal struct CollectionRenderer<MessageType, CustomComponentRendererType: UIK
             right: CGFloat(properties.sectionInset.right)
         )
         
-        switch properties.scrollDirection {
-        case .horizontal:
-            layout.scrollDirection = .horizontal
-        default:
-            layout.scrollDirection = .vertical
-        }
+        layout.scrollDirection = .horizontal
         
         return layout
     }
 }
-

--- a/Sources/UIKit/Renderers/CarouselRenderer.swift
+++ b/Sources/UIKit/Renderers/CarouselRenderer.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 internal struct CarouselRenderer<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UIKitRenderer
-where CustomComponentRendererType.MessageType == MessageType {
+    where CustomComponentRendererType.MessageType == MessageType {
     
     let customComponentRenderer: CustomComponentRendererType
     let properties: CarouselProperties<MessageType>

--- a/Sources/UIKit/Renderers/ComponentRenderer.swift
+++ b/Sources/UIKit/Renderers/ComponentRenderer.swift
@@ -9,70 +9,78 @@
 import UIKit
 
 internal struct ComponentRenderer<MessageType, CustomComponentRendererType: UIKitCustomComponentRenderer>: UIKitRenderer
-    where CustomComponentRendererType.MessageType == MessageType {
-
+where CustomComponentRendererType.MessageType == MessageType {
+    
     let component: Component<MessageType>
     let customComponentRenderer: CustomComponentRendererType
-
+    
     func render(with layoutEngine: LayoutEngine, isDebugModeEnabled: Bool) -> Render<MessageType> {
         switch component {
-
+            
         case .button(let properties, let style, let layout):
             return ButtonRenderer(properties: properties, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .label(let properties, let style, let layout):
             return LabelRenderer(properties: properties, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .textField(let properties, let style, let layout):
             return TextFieldRenderer(properties: properties, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .mapView(let properties, let style, let layout):
             return MapViewRenderer(properties: properties, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .imageView(let image, let style, let layout):
             return ImageViewRenderer(image: image, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .container(let children, let style, let layout):
             return ContainerRenderer(
                 customComponentRenderer: customComponentRenderer,
                 children: children,
                 style: style,
                 layout: layout
-            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            
         case .table(let properties, let style, let layout):
             return TableRenderer(
                 customComponentRenderer: customComponentRenderer,
                 properties: properties,
                 style: style,
                 layout: layout
-            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            
         case .touchable(let gesture, let child):
             return TouchableRenderer(customComponentRenderer: customComponentRenderer, child: child, gesture: gesture)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .segmented(let segments, let style, let layout):
             return SegmentedRenderer(segments: segments, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .collection(let properties, let style, let layout):
             return CollectionRenderer(
                 customComponentRenderer: customComponentRenderer,
                 properties: properties,
                 style: style,
                 layout: layout
-            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            
+        case .carousel(let properties, let style, let layout):
+            return CarouselRenderer(
+                customComponentRenderer: customComponentRenderer,
+                properties: properties,
+                style: style,
+                layout: layout
+                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
             
         case .progress(let progress, let style, let layout):
             return ProgressRenderer(progress: progress, style: style, layout: layout)
                 .render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
-
+            
         case .custom(let componentIdentifier, let layout):
             let customComponentContainerView = UIView()
             layoutEngine.apply(layout: layout, to: customComponentContainerView)
@@ -87,5 +95,5 @@ internal struct ComponentRenderer<MessageType, CustomComponentRendererType: UIKi
             
         }
     }
-
+    
 }

--- a/Sources/UIKit/Renderers/ComponentRenderer.swift
+++ b/Sources/UIKit/Renderers/ComponentRenderer.swift
@@ -43,7 +43,7 @@ where CustomComponentRendererType.MessageType == MessageType {
                 children: children,
                 style: style,
                 layout: layout
-                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
             
         case .table(let properties, let style, let layout):
             return TableRenderer(
@@ -51,7 +51,7 @@ where CustomComponentRendererType.MessageType == MessageType {
                 properties: properties,
                 style: style,
                 layout: layout
-                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
             
         case .touchable(let gesture, let child):
             return TouchableRenderer(customComponentRenderer: customComponentRenderer, child: child, gesture: gesture)
@@ -67,7 +67,7 @@ where CustomComponentRendererType.MessageType == MessageType {
                 properties: properties,
                 style: style,
                 layout: layout
-                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
             
         case .carousel(let properties, let style, let layout):
             return CarouselRenderer(
@@ -75,7 +75,7 @@ where CustomComponentRendererType.MessageType == MessageType {
                 properties: properties,
                 style: style,
                 layout: layout
-                ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
+            ).render(with: layoutEngine, isDebugModeEnabled: isDebugModeEnabled)
             
         case .progress(let progress, let style, let layout):
             return ProgressRenderer(progress: progress, style: style, layout: layout)

--- a/Sources/ZipList.swift
+++ b/Sources/ZipList.swift
@@ -60,14 +60,20 @@ public struct ZipList<Element>: Collection, CustomDebugStringConvertible {
         return i + 1
     }
     
-    public func shiftLeft() -> ZipList<Element>? {
-        guard let newCenter = right.first else { return .none }
-        return ZipList(left: left + [center], center: newCenter, right: Array(right.dropFirst()))
+    public func shiftLeft(count: UInt) -> ZipList<Element>? {
+        guard count <= UInt(right.count) else { return .none }
+        if count == 0 { return self }
+        let newLeft = left + [center] + Array(right.dropLast(right.count - Int(count) - 1))
+        let newRight = Array(right.dropFirst(Int(count)))
+        return ZipList(left: Array(newLeft), center: left[left.count - Int(count)], right: newRight)
     }
     
-    public func shiftRight() -> ZipList<Element>? {
-        guard let newCenter = left.last else { return .none }
-        return ZipList(left: Array(left.dropLast()), center: newCenter, right: [center] + right)
+    public func shiftRight(count: UInt) -> ZipList<Element>? {
+        guard count <= UInt(left.count) else { return .none }
+        if count == 0 { return self }
+        let newLeft = Array(right.dropLast(Int(count)))
+        let newRight = Array(left.dropFirst(left.count + 1 - Int(count))) + [center] + right
+        return ZipList(left: Array(newLeft), center: right[Int(count) - 1], right: newRight)
     }
     
 }

--- a/Sources/ZipList.swift
+++ b/Sources/ZipList.swift
@@ -63,17 +63,17 @@ public struct ZipList<Element>: Collection, CustomDebugStringConvertible {
     public func shiftLeft(count: UInt) -> ZipList<Element>? {
         guard count <= UInt(right.count) else { return .none }
         if count == 0 { return self }
-        let newLeft = left + [center] + Array(right.dropLast(right.count - Int(count) - 1))
+        let newLeft = left + [center] + Array(right.dropLast(right.count + 1 - Int(count)))
         let newRight = Array(right.dropFirst(Int(count)))
-        return ZipList(left: Array(newLeft), center: left[left.count - Int(count)], right: newRight)
+        return ZipList(left: newLeft, center: right[Int(count) - 1], right: newRight)
     }
     
     public func shiftRight(count: UInt) -> ZipList<Element>? {
         guard count <= UInt(left.count) else { return .none }
         if count == 0 { return self }
-        let newLeft = Array(right.dropLast(Int(count)))
+        let newLeft = Array(left.dropLast(Int(count)))
         let newRight = Array(left.dropFirst(left.count + 1 - Int(count))) + [center] + right
-        return ZipList(left: Array(newLeft), center: right[Int(count) - 1], right: newRight)
+        return ZipList(left: newLeft, center: left[left.count - Int(count)], right: newRight)
     }
     
 }


### PR DESCRIPTION
This PR splits the collection component into 2 separate components: the standard `collection` and the new `carousel` component.
This component has specific properties for this style of representation. It has the snap to cell mode, where you can follow the scroll of the carousel and optionally send a message